### PR TITLE
Use MySQL 5.7 and newer mysqlclient library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:trusty
 
+# MySQL 5.7 libs
+RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys A4A9406876FCBD3C456770C88C718D3B5072E1F5 && \
+    echo "deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7" > /etc/apt/sources.list.d/mysql.list
+
 # Ubuntu packages
 RUN apt-get update && \
   apt-get install -y python-pip python-dev curl build-essential pwgen libffi-dev sudo git-core wget \

--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -2,7 +2,7 @@ google-api-python-client==1.2
 gspread==0.2.5
 impyla==0.10.0
 influxdb==2.7.1
-MySQL-python==1.2.5
+mysqlclient==1.3.9
 oauth2client==1.2
 git+https://github.com/vitillo/PyHive.git@deployment#egg=pyhive
 pymongo==3.2.1


### PR DESCRIPTION
This helps stop CVE-2015-3152.

References can be found at:
* https://github.com/PyMySQL/mysqlclient-python/issues/98
* https://github.com/mozilla/treeherder/blob/master/bin/vendor-libmysqlclient.sh
* https://bugzilla.mozilla.org/show_bug.cgi?id=1289156
