### PR TITLE
89 data source version in UI

### DIFF
--- a/client/app/pages/data-sources/show.js
+++ b/client/app/pages/data-sources/show.js
@@ -55,7 +55,6 @@ function DataSourceCtrl($scope, $routeParams, $http, $location, toastr,
 
     DataSource.version(
       { id: $scope.dataSource.id }, (httpResponse) => {
-        console.log(httpResponse);
         if (httpResponse.ok) {
           const versionNumber = httpResponse.message;
           toastr.success(`Success. Verison: ${versionNumber}`);
@@ -64,7 +63,6 @@ function DataSourceCtrl($scope, $routeParams, $http, $location, toastr,
         }
         callback();
       }, (httpResponse) => {
-        console.log(httpResponse);
         logger('Failed to get data source version: ', httpResponse.status, httpResponse.statusText, httpResponse);
         toastr.error('Unknown error occurred while performing data source version test. Please try again later.', 'Data Source Version Test Failed:', { timeOut: 10000 });
         callback();

--- a/client/app/pages/data-sources/show.js
+++ b/client/app/pages/data-sources/show.js
@@ -57,7 +57,7 @@ function DataSourceCtrl($scope, $routeParams, $http, $location, toastr,
       { id: $scope.dataSource.id }, (httpResponse) => {
         if (httpResponse.ok) {
           const versionNumber = httpResponse.message;
-          toastr.success(`Success. Verison: ${versionNumber}`);
+          toastr.success(`Success. Version: ${versionNumber}`);
         } else {
           toastr.error(httpResponse.message, 'Version Test Failed:', { timeOut: 10000 });
         }

--- a/client/app/pages/data-sources/show.js
+++ b/client/app/pages/data-sources/show.js
@@ -50,9 +50,31 @@ function DataSourceCtrl($scope, $routeParams, $http, $location, toastr,
     });
   }
 
+  function getDataSourceVersion(callback) {
+    Events.record('test', 'data_source_version', $scope.dataSource.id);
+
+    DataSource.version(
+      { id: $scope.dataSource.id }, (httpResponse) => {
+        console.log(httpResponse);
+        if (httpResponse.ok) {
+          const versionNumber = httpResponse.message;
+          toastr.success(`Success. Verison: ${versionNumber}`);
+        } else {
+          toastr.error(httpResponse.message, 'Version Test Failed:', { timeOut: 10000 });
+        }
+        callback();
+      }, (httpResponse) => {
+        console.log(httpResponse);
+        logger('Failed to get data source version: ', httpResponse.status, httpResponse.statusText, httpResponse);
+        toastr.error('Unknown error occurred while performing data source version test. Please try again later.', 'Data Source Version Test Failed:', { timeOut: 10000 });
+        callback();
+      });
+  }
+
   $scope.actions = [
     { name: 'Delete', class: 'btn-danger', callback: deleteDataSource },
     { name: 'Test Connection', class: 'btn-default', callback: testConnection, disableWhenDirty: true },
+    { name: 'Test Data Source Version', class: 'btn-default', callback: getDataSourceVersion, disableWhenDirty: true },
   ];
 }
 

--- a/client/app/pages/queries/get-data-source-version.js
+++ b/client/app/pages/queries/get-data-source-version.js
@@ -1,12 +1,15 @@
-function GetDataSourceVersionCtrl(Events, toastr, $scope, DataSource) {
+function GetDataSourceVersionCtrl(Events, toastr, $scope, DataSource, $route) {
   // 'ngInject';
 
-  this.getDataSourceVersion = DataSource.version({ id: 6 });
+  this.getDataSourceVersion = DataSource.version(
+    {
+      id: $route.current.locals.query.data_source_id,
+    }
+  );
 }
 
 const GetDataSourceVersionInfo = {
   bindings: {
-    schema: '<',
     onRefresh: '&',
   },
   controller: GetDataSourceVersionCtrl,

--- a/client/app/pages/queries/get-data-source-version.js
+++ b/client/app/pages/queries/get-data-source-version.js
@@ -13,7 +13,7 @@ const GetDataSourceVersionInfo = {
     onRefresh: '&',
   },
   controller: GetDataSourceVersionCtrl,
-  template: '<span>{{ $ctrl.getDataSourceVersion.message }}</span>',
+  template: '<span ng-if=\'!$ctrl.getDataSourceVersion.message.includes("not")\'>{{ $ctrl.getDataSourceVersion.message  }}</span><span ng-if=\'$ctrl.getDataSourceVersion.message.includes("not")\' class=\'fa fa-exclamation-circle\' data-toggle=\'tooltip\' data-placement=\'right\' tooltip title=\'{{ $ctrl.getDataSourceVersion.message }}\'></span>',
 };
 
 export default function (ngModule) {

--- a/client/app/pages/queries/get-data-source-version.js
+++ b/client/app/pages/queries/get-data-source-version.js
@@ -1,0 +1,18 @@
+function GetDataSourceVersionCtrl(Events, toastr, $scope, DataSource) {
+  // 'ngInject';
+
+  this.getDataSourceVersion = DataSource.version({ id: 6 });
+}
+
+const GetDataSourceVersionInfo = {
+  bindings: {
+    schema: '<',
+    onRefresh: '&',
+  },
+  controller: GetDataSourceVersionCtrl,
+  template: '<span>{{ $ctrl.getDataSourceVersion.message }}</span>',
+};
+
+export default function (ngModule) {
+  ngModule.component('getDataSourceVersion', GetDataSourceVersionInfo);
+}

--- a/client/app/pages/queries/index.js
+++ b/client/app/pages/queries/index.js
@@ -10,6 +10,7 @@ import registerAlertUnsavedChanges from './alert-unsaved-changes';
 import registerQuerySearchResultsPage from './queries-search-results-page';
 import registerVisualizationEmbed from './visualization-embed';
 import registerCompareQueryDialog from './compare-query-dialog';
+import registerGetDataSourceVersion from './get-data-source-version';
 
 export default function (ngModule) {
   registerQueryResultsLink(ngModule);
@@ -21,6 +22,7 @@ export default function (ngModule) {
   registerVisualizationEmbed(ngModule);
   registerCompareQueryDialog(ngModule);
   registerApiKeyDialog(ngModule);
+  registerGetDataSourceVersion(ngModule);
 
   return Object.assign({}, registerQuerySearchResultsPage(ngModule),
                            registerSourceView(ngModule),

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -103,7 +103,7 @@
               <select id="data-source-selection" ng-disabled="!isQueryOwner" ng-model="query.data_source_id" ng-change="updateDataSource()"
                       ng-options="ds.id as ds.name for ds in dataSources"></select>
               <a ng-if="dataSource.options.doc_url != ''" ng-href={{dataSource.options.doc_url}}>{{dataSource.type_name}} documentation</a>
-              <get-data-source-version></get-data-source-version>
+              <get-data-source-version id='data-source-version'></get-data-source-version>
               
               <div class="pull-right">
                 <button class="btn btn-s btn-default" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -104,6 +104,8 @@
                       ng-options="ds.id as ds.name for ds in dataSources"></select>
               <a ng-if="dataSource.options.doc_url != ''" ng-href={{dataSource.options.doc_url}}>{{dataSource.type_name}} documentation</a>
               <span ng-if="dataSource.options.doc_url == ''">{{dataSource.type_name}}</span>
+              <get-data-source-version></get-data-source-version>
+              
               <div class="pull-right">
                 <button class="btn btn-s btn-default" ng-click="togglePublished()" ng-if="query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))">
                   <span class="fa fa-paper-plane"></span> Publish

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -100,10 +100,9 @@
 
               <i class="fa fa-database"></i>
               <span class="text-muted">Data Source</span>
-              <select ng-disabled="!isQueryOwner" ng-model="query.data_source_id" ng-change="updateDataSource()"
+              <select id="data-source-selection" ng-disabled="!isQueryOwner" ng-model="query.data_source_id" ng-change="updateDataSource()"
                       ng-options="ds.id as ds.name for ds in dataSources"></select>
               <a ng-if="dataSource.options.doc_url != ''" ng-href={{dataSource.options.doc_url}}>{{dataSource.type_name}} documentation</a>
-              <span ng-if="dataSource.options.doc_url == ''">{{dataSource.type_name}}</span>
               <get-data-source-version></get-data-source-version>
               
               <div class="pull-right">

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -254,6 +254,7 @@ function QueryViewCtrl($scope, Events, $route, $routeParams, $location, $window,
 
     updateSchema();
     $scope.dataSource = find($scope.dataSources, ds => ds.id === $scope.query.data_source_id);
+    document.getElementById('data-source-version').innerHTML = '<span class=\'fa fa-refresh\' data-toggle=\'tooltip\' data-placement=\'right\' tooltip title=\'refresh page to get version\'></span>';
   };
 
   $scope.setVisualizationTab = (visualization) => {

--- a/client/app/services/data-source.js
+++ b/client/app/services/data-source.js
@@ -4,6 +4,7 @@ function DataSource($resource) {
     query: { method: 'GET', cache: false, isArray: true },
     test: { method: 'POST', cache: false, isArray: false, url: 'api/data_sources/:id/test' },
     getSchema: { method: 'GET', cache: false, isArray: true, url: 'api/data_sources/:id/schema' },
+    version: { method: 'GET', cache: false, isArray: false, url: 'api/data_sources/:id/version' },
   };
 
   const DataSourceResource = $resource('api/data_sources/:id', { id: '@id' }, actions);

--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -57,7 +57,7 @@ def test(name, organization='default'):
             name, data_source.id)
         try:
             data_source.query_runner.test_connection()
-        except Exception, e:
+        except Exception as e:
             print "Failure: {}".format(e)
             exit(1)
         else:
@@ -82,7 +82,7 @@ def get_data_source_version(name, organization='default'):
             name, data_source.id)
         try:
             info = data_source.query_runner.get_data_source_version()
-        except Exception, e:
+        except Exception as e:
             print "Failure: {}".format(e)
             exit(1)
         else:

--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -66,6 +66,30 @@ def test(name, organization='default'):
         print "Couldn't find data source named: {}".format(name)
         exit(1)
 
+@manager.command()
+@click.argument('name')
+@click.option('--org', 'organization', default='default',
+              help="The organization the user belongs to "
+              "(leave blank for 'default').")
+def get_data_source_version(name, organization='default'):
+    """Get version of data source connection by issuing a trivial query."""
+    try:
+        org = models.Organization.get_by_slug(organization)
+        data_source = models.DataSource.query.filter(
+            models.DataSource.name == name,
+            models.DataSource.org == org).one()
+        print "Testing get connection data source version: {} (id={})".format(
+            name, data_source.id)
+        try:
+            info = data_source.query_runner.get_data_source_version()
+        except Exception, e:
+            print "Failure: {}".format(e)
+            exit(1)
+        else:
+            print info
+    except NoResultFound:
+        print "Couldn't find data source named: {}".format(name)
+        exit(1)
 
 @manager.command()
 @click.argument('name', default=None, required=False)

--- a/redash/handlers/api.py
+++ b/redash/handlers/api.py
@@ -7,7 +7,7 @@ from redash.handlers.base import org_scoped_rule
 from redash.handlers.permissions import ObjectPermissionsListResource, CheckPermissionResource
 from redash.handlers.alerts import AlertResource, AlertListResource, AlertSubscriptionListResource, AlertSubscriptionResource
 from redash.handlers.dashboards import DashboardListResource, RecentDashboardsResource, DashboardResource, DashboardShareResource, PublicDashboardResource
-from redash.handlers.data_sources import DataSourceTypeListResource, DataSourceListResource, DataSourceSchemaResource, DataSourceResource, DataSourcePauseResource, DataSourceTestResource
+from redash.handlers.data_sources import DataSourceTypeListResource, DataSourceListResource, DataSourceSchemaResource, DataSourceResource, DataSourcePauseResource, DataSourceTestResource, DataSourceVersionResource
 from redash.handlers.events import EventResource
 from redash.handlers.queries import (
     MyQueriesResource, QueryForkResource, QueryListResource,
@@ -58,6 +58,7 @@ api.add_org_resource(DataSourceListResource, '/api/data_sources', endpoint='data
 api.add_org_resource(DataSourceSchemaResource, '/api/data_sources/<data_source_id>/schema')
 api.add_org_resource(DataSourcePauseResource, '/api/data_sources/<data_source_id>/pause')
 api.add_org_resource(DataSourceTestResource, '/api/data_sources/<data_source_id>/test')
+api.add_org_resource(DataSourceVersionResource, '/api/data_sources/<data_source_id>/version')
 api.add_org_resource(DataSourceResource, '/api/data_sources/<data_source_id>', endpoint='data_source')
 
 api.add_org_resource(GroupListResource, '/api/groups', endpoint='groups')

--- a/redash/handlers/data_sources.py
+++ b/redash/handlers/data_sources.py
@@ -164,3 +164,16 @@ class DataSourceTestResource(BaseResource):
             return {"message": unicode(e), "ok": False}
         else:
             return {"message": "success", "ok": True}
+
+class DataSourceVersionResource(BaseResource):
+    def get(self, data_source_id):
+        data_source = get_object_or_404(models.DataSource.get_by_id_and_org, data_source_id, self.current_org)
+        require_access(data_source.groups, self.current_user, view_only)
+        try:
+            version_info = data_source.query_runner.get_data_source_version()
+        except Exception as e:
+            return {"message": unicode(e), "ok": False}
+        else:
+            return {"message": version_info, "ok": True}
+
+

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -77,16 +77,21 @@ class BaseQueryRunner(object):
         if self.data_source_version_query is None:
             raise NotImplementedError
         data, error = self.run_query(self.data_source_version_query, None)
-        version = json.loads(data)['rows'][0]['version']
-        if(self.data_source_version_post_process == "split by space take second"):
-            version = version.split(" ")[1]
-        elif(self.data_source_version_post_process == "split by space take last"):
-            version = version.split(" ")[-1]
-        elif(self.data_source_version_post_process == "none"):
-            version = version
-        
+
         if error is not None:
             raise Exception(error)
+
+        try:
+            version = json.loads(data)['rows'][0]['version']
+        except KeyError as e:
+            raise Exception(e)
+            
+        if self.data_source_version_post_process == "split by space take second":
+            version = version.split(" ")[1]
+        elif self.data_source_version_post_process == "split by space take last":
+            version = version.split(" ")[-1]
+        elif self.data_source_version_post_process == "none":
+            version = version
 
         return version
 

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -80,6 +80,10 @@ class BaseQueryRunner(object):
         version = json.loads(data)['rows'][0]['version']
         if(self.data_source_version_post_process == "split by space take second"):
             version = version.split(" ")[1]
+        elif(self.data_source_version_post_process == "split by space take last"):
+            version = version.split(" ")[-1]
+        elif(self.data_source_version_post_process == "none"):
+            version = version
         
         if error is not None:
             raise Exception(error)

--- a/redash/query_runner/__init__.py
+++ b/redash/query_runner/__init__.py
@@ -73,6 +73,19 @@ class BaseQueryRunner(object):
     def configuration_schema(cls):
         return {}
 
+    def get_data_source_version(self):
+        if self.data_source_version_query is None:
+            raise NotImplementedError
+        data, error = self.run_query(self.data_source_version_query, None)
+        version = json.loads(data)['rows'][0]['version']
+        if(self.data_source_version_post_process == "split by space take second"):
+            version = version.split(" ")[1]
+        
+        if error is not None:
+            raise Exception(error)
+
+        return version
+
     def test_connection(self):
         if self.noop_query is None:
             raise NotImplementedError()

--- a/redash/query_runner/mysql.py
+++ b/redash/query_runner/mysql.py
@@ -30,6 +30,8 @@ types_map = {
 class Mysql(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
     default_doc_url = 'https://dev.mysql.com/doc/refman/5.7/en/'
+    data_source_version_query = "select version()"
+    data_source_version_post_process = "none"
 
     @classmethod
     def configuration_schema(cls):

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -48,6 +48,8 @@ def _wait(conn, timeout=None):
 class PostgreSQL(BaseSQLQueryRunner):
     noop_query = "SELECT 1"
     default_doc_url = "https://www.postgresql.org/docs/current/"
+    data_source_version_query = "select version()"
+    data_source_version_post_process = "split by space take second"
 
     @classmethod
     def configuration_schema(cls):

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -184,6 +184,8 @@ class PostgreSQL(BaseSQLQueryRunner):
 class Redshift(PostgreSQL):
     default_doc_url = ("http://docs.aws.amazon.com/redshift/latest/"
                        "dg/cm_chap_SQLCommandRef.html")
+    data_source_version_query = "select version()"
+    data_source_version_post_process = "split by space take last"
 
     @classmethod
     def type(cls):


### PR DESCRIPTION
#89

This adds a button to get data source version on the data source configuration page and to display it in the query runner next to the documentation link.

SQL dialects supported are postgres, mysql, and redshift. I couldn’t find "what version am i running?" queries for Presto, Athena, and BigQuery.