### PR TITLE
Fix error overlaps save button

### DIFF
--- a/client/app/pages/dashboards/widget.js
+++ b/client/app/pages/dashboards/widget.js
@@ -40,6 +40,8 @@ function DashboardWidgetCtrl($location, $uibModal, $window, Events, currentUser)
       resolve: {
         widget: this.widget,
       },
+      backdrop: 'static',
+      keyboard: false,
     });
   };
 


### PR DESCRIPTION
addresses issue Madalin found that allows a click off the dialog box to
close it without resetting the textbox

#54