### PR TITLE
convert angle brackets in strings to html entities (re #222)

### DIFF
--- a/client/app/visualizations/table/index.js
+++ b/client/app/visualizations/table/index.js
@@ -29,7 +29,8 @@ function formatValue($filter, clientConfig, value, type) {
       break;
     default:
       if (isString(value)) {
-        formattedValue = $filter('linkify')(value);
+        formattedValue = $filter('linkify')(value.replace(
+            /[\u00A0-\u9999<>&'"]/gim, i => `&#${i.charCodeAt(0)};`));
       }
       break;
   }


### PR DESCRIPTION
Testable by running `select '{"<unknown>": 1}';` in any data source