### PR TITLE
Fix downgrade hash in search vector migration

### DIFF
--- a/migrations/versions/5ec5c84ba61e_.py
+++ b/migrations/versions/5ec5c84ba61e_.py
@@ -13,7 +13,7 @@ import sqlalchemy_searchable as ss
 
 # revision identifiers, used by Alembic.
 revision = '5ec5c84ba61e'
-down_revision = 'd1eae8b9893e'
+down_revision = 'eb2f788f997e'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
to use our intermediate migration added in 9844c6f606828da0d4c53308eaa9d7ce49b917a4.