### PR TITLE
Fix downgrade hash in search vector migration again

### DIFF
--- a/migrations/versions/5ec5c84ba61e_.py
+++ b/migrations/versions/5ec5c84ba61e_.py
@@ -13,7 +13,7 @@ import sqlalchemy_searchable as ss
 
 # revision identifiers, used by Alembic.
 revision = '5ec5c84ba61e'
-down_revision = 'eb2f788f997e'
+down_revision = '58f810489c47'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
to use our intermediate migration added in ab23e21f6f4ac780fe1bc1884dc3a0b25dfff5ca.