### PR TITLE
Update query version when saving new data source

### DIFF
--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -254,6 +254,8 @@ function QueryViewCtrl(
         id: $scope.query.id,
         data_source_id: $scope.query.data_source_id,
         latest_query_data_id: null,
+      }, (updatedQuery) => {
+        $scope.query.version = updatedQuery.version;
       });
     }
 


### PR DESCRIPTION
This fixes #281.

Choosing a new data source for a query immediately updates the server-side record; the client-side 'version' attribute was not being updated afterwards and so subsequent saves were treated as though they were out of sync, leading to the error shown.