### PR TITLE
Unique names for query parameters (refs #164)

### DIFF
--- a/client/app/components/parameters.js
+++ b/client/app/components/parameters.js
@@ -123,7 +123,7 @@ function ParametersDirective($location, $uibModal) {
           }
           scope.parameters.forEach((param) => {
             if (param.value !== null || param.value !== '') {
-              $location.search(`p_${param.name}`, param.value);
+              $location.search(`p_${param.name}_${param.queryId}`, param.value);
             }
           });
         }, true);

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -138,12 +138,12 @@ class Parameters {
     const parameterExists = p => contains(parameterNames, p.name);
     this.query.options.parameters = this.query.options.parameters
       .filter(parameterExists)
-      .map(p => new Parameter(p));
+      .map(p => new Parameter(Object.assign({queryId: this.query.id}, p)));
   }
 
   initFromQueryString(queryString) {
     this.get().forEach((param) => {
-      const queryStringName = `p_${param.name}`;
+      const queryStringName = `p_${param.name}_${this.query.id}`;
       if (has(queryString, queryStringName)) {
         param.value = queryString[queryStringName];
       }
@@ -335,7 +335,7 @@ function QueryResource($resource, $http, $q, $location, currentUser, QueryResult
           params += '&';
         }
 
-        params += `p_${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+        params += `p_${encodeURIComponent(name)}_${this.id}=${encodeURIComponent(value)}`;
       });
     }
 


### PR DESCRIPTION
This puts the query ID in the URL parameters, so that when multiple queries in a dashboard have a parameter of the same name, they don't get confused.

(fixes #164)