### PR TITLE
Extend the Remote User Auth backend with REMOTE_GROUPS ability

### DIFF
--- a/redash/authentication/remote_user_auth.py
+++ b/redash/authentication/remote_user_auth.py
@@ -30,6 +30,21 @@ def login(org_slug=None):
         logger.error("Cannot use remote user for login when it's not provided in the request (looked in headers['" + settings.REMOTE_USER_HEADER + "'])")
         return redirect(url_for('redash.index', next=next_path, org_slug=org_slug))
 
+    # Check if there is a header of user groups and if yes
+    # check it against a list of allowed user groups from the settings
+    if settings.REMOTE_GROUPS_ENABLED:
+        remote_groups = settings.set_from_string(
+            request.headers.get(settings.REMOTE_GROUPS_HEADER) or ''
+        )
+        allowed_groups = settings.REMOTE_GROUPS_ALLOWED
+        if not allowed_groups.intersection(remote_groups):
+            logger.error(
+                "User groups provided in the %s header are not "
+                "matching the allowed groups.",
+                settings.REMOTE_GROUPS_HEADER
+            )
+            return redirect(url_for('redash.index', next=next_path))
+
     logger.info("Logging in " + email + " via remote user")
     create_and_login_user(current_org, email, email)
     return redirect(next_path or url_for('redash.index', org_slug=org_slug), code=302)

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -83,6 +83,13 @@ GOOGLE_OAUTH_ENABLED = GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET
 REMOTE_USER_LOGIN_ENABLED = parse_boolean(os.environ.get("REDASH_REMOTE_USER_LOGIN_ENABLED", "false"))
 REMOTE_USER_HEADER = os.environ.get("REDASH_REMOTE_USER_HEADER", "X-Forwarded-Remote-User")
 
+# When enabled this will match the given remote groups request header with a
+# configured list of allowed user groups using UNIX shell-style wildcards such
+# as * and ?.
+REMOTE_GROUPS_ENABLED = parse_boolean(os.environ.get("REDASH_REMOTE_GROUPS_ENABLED", "false"))
+REMOTE_GROUPS_HEADER = os.environ.get("REDASH_REMOTE_GROUPS_HEADER", "X-Forwarded-Remote-Groups")
+REMOTE_GROUPS_ALLOWED = set_from_string(os.environ.get("REDASH_REMOTE_GROUPS_ALLOWED", ""))
+
 # If the organization setting auth_password_login_enabled is not false, then users will still be
 # able to login through Redash instead of the LDAP server
 LDAP_LOGIN_ENABLED = parse_boolean(os.environ.get('REDASH_LDAP_LOGIN_ENABLED', 'false'))

--- a/redash/settings/helpers.py
+++ b/redash/settings/helpers.py
@@ -31,7 +31,7 @@ def array_from_string(s):
     if "" in array:
         array.remove("")
 
-    return array
+    return [item.strip() for item in array]
 
 
 def set_from_string(s):


### PR DESCRIPTION
If enabled the feature allows checking the header value against a configured list of group names, including the ability to use UNIX shell-style wildcards.