### PR TITLE
Add a Redash extension system based on Python entrypoints.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -45,9 +45,10 @@ pystache==0.5.4
 parsedatetime==2.1
 cryptography==2.0.2
 simplejson==3.10.0
-ua-parser==0.7.3 
+ua-parser==0.7.3
 user-agents==1.1.0
 python-geoip-geolite2==2015.303
 # Uncomment the requirement for ldap3 if using ldap.
 # It is not included by default because of the GPL license conflict.
 # ldap3==2.2.4
+redash-stmo>=2018.2.2


### PR DESCRIPTION
This is along the lines of what Flask does for CLI plugins:

  http://flask.pocoo.org/docs/0.12/cli/#cli-plugins

The API allows specifying Python callbacks that receive the
Redash Flask app as the only argument and allow extending
the Redash process with the usual Flask API as needed. This
does not cover front-end specific extensions (yet).