### PR TITLE
Updates to docker-entrypoint for worker and scheduler

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -7,7 +7,7 @@ worker() {
   QUEUES=${QUEUES:-queries,scheduled_queries,celery}
 
   echo "Starting $WORKERS_COUNT workers for queues: $QUEUES..."
-  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --maxtasksperchild=10 -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 -Ofair
 }
 
 scheduler() {
@@ -17,7 +17,7 @@ scheduler() {
 
   echo "Starting scheduler and $WORKERS_COUNT workers for queues: $QUEUES..."
 
-  exec /usr/local/bin/celery worker --app=redash.worker --beat -c$WORKERS_COUNT -Q$QUEUES -linfo --maxtasksperchild=10 -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker --beat -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 -Ofair
 }
 
 server() {

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -8,7 +8,10 @@ worker() {
   MAX_MEMORY=$(($(/usr/bin/awk '/MemTotal/ {print $2}' /proc/meminfo)/4))
 
   echo "Starting $WORKERS_COUNT workers for queues: $QUEUES..."
-  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 --max-memory-per-child=$MEMORY -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo \
+      --max-tasks-per-child=10 \
+      --max-memory-per-child=$MEMORY \
+      -Ofair
 }
 
 scheduler() {
@@ -18,7 +21,9 @@ scheduler() {
 
   echo "Starting scheduler and $WORKERS_COUNT workers for queues: $QUEUES..."
 
-  exec /usr/local/bin/celery worker --app=redash.worker --beat -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker --beat -c$WORKERS_COUNT -Q$QUEUES -linfo \
+      --max-tasks-per-child=10 \
+      -Ofair
 }
 
 server() {

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -10,7 +10,7 @@ worker() {
   echo "Starting $WORKERS_COUNT workers for queues: $QUEUES..."
   exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo \
       --max-tasks-per-child=10 \
-      --max-memory-per-child=$MEMORY \
+      --max-memory-per-child=$MAX_MEMORY \
       -Ofair
 }
 

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,9 +5,10 @@ worker() {
   /app/manage.py db upgrade
   WORKERS_COUNT=${WORKERS_COUNT:-2}
   QUEUES=${QUEUES:-queries,scheduled_queries,celery}
+  MAX_MEMORY=$(($(/usr/bin/awk '/MemTotal/ {print $2}' /proc/meminfo)/4))
 
   echo "Starting $WORKERS_COUNT workers for queues: $QUEUES..."
-  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 -Ofair
+  exec /usr/local/bin/celery worker --app=redash.worker -c$WORKERS_COUNT -Q$QUEUES -linfo --max-tasks-per-child=10 --max-memory-per-child=$MEMORY -Ofair
 }
 
 scheduler() {


### PR DESCRIPTION
I've added `--max-memory-per-child` to 1/4 of the available system memory. I think this will assist with workers being reaped by OOMKiller and other memory issues we have seen.

`--maxtasksperchild` was renamed to `--max-tasks-per-child` in Celery 4 [1].

/cc @robotblake 

r? 

[1] https://github.com/celery/celery/blob/8047ca9e818db8151dc6c80814600797ab94f5bc/docs/history/whatsnew-4.0.rst#worker