### PR TITLE
Closes #374: Truncating x-axis should be done to ticktext not x values.

### DIFF
--- a/client/app/visualizations/chart/plotly/utils.js
+++ b/client/app/visualizations/chart/plotly/utils.js
@@ -183,12 +183,11 @@ function preparePieData(seriesList, options) {
   } = calculateDimensions(seriesList, options);
 
   const colorPalette = ColorPaletteArray.slice();
-  const xAxisLabelLength = parseInt(options.xAxisLabelLength, 10) || DEFAULT_XAXIS_LABEL_LENGTH;
   return map(seriesList, (serie, index) => {
     const xPosition = (index % cellsInRow) * cellWidth;
     const yPosition = Math.floor(index / cellsInRow) * cellHeight;
     const labels = map(serie.data, (row, rowIdx) => {
-      const rowX = hasX ? row.x.substr(0, xAxisLabelLength) : `Slice ${index}`;
+      const rowX = hasX ? row.x : `Slice ${index}`;
       const rowOpts = options.seriesOptions[rowX];
       if (rowOpts) {
         colorPalette[rowIdx] = rowOpts.color;
@@ -230,8 +229,7 @@ function prepareChartData(seriesList, options) {
     const yValues = [];
     const yErrorValues = [];
     each(data, (row) => {
-      const xAxisLabelLength = parseInt(options.xAxisLabelLength, 10) || DEFAULT_XAXIS_LABEL_LENGTH;
-      const x = normalizeValue(row.x).substr(0, xAxisLabelLength);
+      const x = normalizeValue(row.x);
       const y = normalizeValue(row.y);
       const yError = normalizeValue(row.yError);
       sourceData.set(x, {
@@ -378,6 +376,19 @@ export function prepareLayout(element, seriesList, options, data) {
     if (options.series.stacking) {
       result.barmode = 'relative';
     }
+  }
+
+  // Truncate x-axis labels using ticktext.
+  // Example can be found here: https://plot.ly/javascript/axes/#enumerated-ticks-with-tickvals-and-ticktext
+  let ticktext, tickvals;
+  const xAxisLabelLength = parseInt(options.xAxisLabelLength, 10) || DEFAULT_XAXIS_LABEL_LENGTH;
+  if (data.length > 0) {
+    ticktext = map(data[0].x, xVal => String(xVal).substr(0, xAxisLabelLength));
+    tickvals = data[0].x;
+  }
+  if (ticktext && tickvals) {
+    result.xaxis.ticktext = ticktext;
+    result.xaxis.tickvals = tickvals;
   }
 
   return result;


### PR DESCRIPTION
For some context/background:

1. This commit originally did x-axis truncation but only for pie charts: https://github.com/mozilla/redash/commit/3087822
2. A similar method of truncation was used in this commit to also be applied to other charts: https://github.com/mozilla/redash/commit/eb1b3cb
3. Issue https://github.com/mozilla/redash/issues/374 came up because when x-axis values were numeric, the attempt to truncate them failed. This turned out to be the case for pie charts too but I suppose they aren't used as often so the issue was not filed sooner.
4. This PR keeps `tickvals` as the original numeric values but adds an additional array of truncated text, `ticktext`. The truncation issue should still be resolved as well as the ability to have numeric x-axis values.

Here are a couple of queries to test with:

For numeric x-axis:
```
WITH sample AS
    (select 26191 as a, 121370 as b, 21.58 as c union
     select 26591 as a, 121170 as b, 11.53 as c union
     select 26598 as a, 121170 as b, 22.58 as c union
     select 26594 as a, 121170 as b, 41.58 as c union
     select 26592 as a, 121170 as b, 51.58 as c union
     select 16596 as a, 121170 as b, 11.58 as c union
     select 26593 as a, 121170 as b, 31.58 as c union
     select 26597 as a, 121170 as b, 81.58 as c union
     select 56599 as a, 121170 as b, 21.58 as c)
select a, b, c from sample
```

For correctly truncated x-axis:
```
WITH sample as (
    select '2017-12-10 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-11 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-12 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-13 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-14 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-15 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-16 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-17 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-18 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-19 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-20 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-21 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-22 00:00' as x, 'US' as type, 8215767 as foo union
    select '2017-12-23 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-24 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-25 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-26 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-27 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-28 00:00' as x, 'US' as type, 8215767 as foo union
    select '2017-12-29 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-30 00:00' as x, 'US' as type, 8215767 as foo union
    select '2017-12-31 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-32 00:00' as x, 'US' as type, 8215767 as foo union
    select '2017-12-33 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-34 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-35 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-36 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-37 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-38 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-39 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-40 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-41 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-42 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-43 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-44 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-45 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-46 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-47 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-48 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-49 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-50 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-51 00:00' as x, 'US' as type, 574047 as foo union
    select '2017-12-52 00:00' as x, 'ROW' as type, 8215767 as foo)
select * from sample
```
