### PR TITLE
Closes #369: Correct datasource documentation link alignment.

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -455,6 +455,7 @@ edit-in-place p.editable:hover {
 
 .datasource-small {
   visibility: hidden;
+  display: none !important;
 }
 
 .query-fullscreen .query-metadata__mobile {
@@ -554,6 +555,7 @@ nav .rg-bottom {
 
   .datasource-small {
     visibility: visible;
+    display: inline-block !important;
   }
 
   .query-fullscreen {


### PR DESCRIPTION
Turns out there was another datasource dropdown that is hidden on larger screens but still taking up space.

Used `display: none;` to remove the space it takes up. Needed to use `!important` because the `select` tag here also has the `form-control` class which was overriding values for `display`: https://github.com/mozilla/redash/blob/master/client/app/pages/queries/query.html#L152.

Here are screenshots with the bug fix:

On large screens:
<img width="1254" alt="screen shot 2018-05-04 at 2 57 09 pm" src="https://user-images.githubusercontent.com/784781/39647574-82cc8e5e-4fad-11e8-889c-64cb1c37ebef.png">

On small screens:
<img width="800" alt="screen shot 2018-05-04 at 2 57 28 pm" src="https://user-images.githubusercontent.com/784781/39647580-875dbee8-4fad-11e8-8439-446b3edf4e9b.png">

