### PR TITLE
Closes #396: Integration with Flower.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,3 +41,13 @@ services:
     # tests.
     command: "postgres -c fsync=off -c full_page_writes=off -c synchronous_commit=OFF"
     restart: unless-stopped
+  flower:
+    image: mher/flower:latest
+    command: flower
+    environment:
+      CELERY_BROKER_URL: redis://redis:6379/0
+      CELERY_RESULT_BACKEND: redis://redis:6379/0
+    ports:
+      - "5555:5555"
+    links:
+      - redis


### PR DESCRIPTION
Can view flower locally at `http://localhost:5555`

Note: this relies on an existing image in Docker Hub, but perhaps it's better to make our own if we need to customize it. For now, however, this works locally.