### PR TITLE
Add experimental ability to open up a query in an iodide notebook

### DIFF
--- a/client/app/pages/queries/iodide-template.html
+++ b/client/app/pages/queries/iodide-template.html
@@ -1,0 +1,20 @@
+%% meta
+{"title": "{{ title }}"}
+
+%% md
+This is an iodide notebook, for more information and tutorials see https://iodide.io
+
+%% js
+// this cell fetches the results of your stmo query ({{ title }})
+iodide.evalQueue.requireExplicitContinuation();
+var stmoData;
+let url = '{{ jsonUrl }}';
+fetch(url)
+  .then(response => response.json())
+  .then((json)=> {stmoData = json; iodide.evalQueue.continue()});
+
+%% js
+// You can now access the results of your stmo query from the "stmoData" variable
+// As an example, we are going to assemble the rows of the query into a simple
+// data structure
+stmoData.query_result.data.rows.map(row=>Object.values(row))

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -65,6 +65,7 @@
             <li ng-if="!query.is_draft && query.id != undefined && (isQueryOwner || currentUser.hasPermission('admin'))"><a ng-click="togglePublished()">Unpublish</a></li>
             <li class="divider" ng-if="!query.is_archived"></li>
             <li ng-if="query.id != undefined"><a ng-click="showApiKey()">Show API Key</a></li>
+            <li ng-if="query.id != undefined"><a href="{{ iodideUrl }}">Open in Iodide Notebook (experimental)</a></li>
             <li ng-show="canEdit" ng-if="query.id && (query.version > 1)">
               <a ng-click="compareQueryVersion()">Query Versions</a>
             </li>

--- a/client/app/pages/queries/view.js
+++ b/client/app/pages/queries/view.js
@@ -1,12 +1,14 @@
 import { pick, any, some, find, min, isObject } from 'underscore';
 import { SCHEMA_NOT_SUPPORTED, SCHEMA_LOAD_ERROR } from '@/services/data-source';
 import template from './query.html';
+import iodideTemplate from './iodide-template.html';
 
 function QueryViewCtrl(
   $scope,
   Events,
   $route,
   $routeParams,
+  $interpolate,
   $location,
   $window,
   $q,
@@ -172,6 +174,12 @@ function QueryViewCtrl(
       },
     });
   };
+
+  const iodideNotebookJsmd = $interpolate(iodideTemplate)({
+    title: $scope.query.name,
+    jsonUrl: `${clientConfig.basePath}api/queries/${$scope.query.id}/results.json?api_key=${$scope.query.api_key}`,
+  });
+  $scope.iodideUrl = `https://iodide.io/master/?jsmd=${encodeURIComponent(iodideNotebookJsmd)}`;
 
   $scope.duplicateQuery = () => {
     Query.fork({ id: $scope.query.id }, (newQuery) => {


### PR DESCRIPTION
This is a bit of a hack in a lot of ways (not the least of which the
fact that we're using the url as a serialization/transport mechanism), but
might be interesting from the point of view of making it easier to interact
with an stmo query via an iodide notebook.

I'd like us to consider merging this (at least on a temporary basis) as a
sort of "MVP" while we work on more sophisticated workflows to move between
redash and iodide.