### PR TITLE
Show number of queries in queue while waiting for execution

### DIFF
--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -213,7 +213,7 @@
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                 </div>
                 <div class="alert alert-info m-t-15" ng-show="queryResult.getStatus() == 'waiting'">
-                  Query in queue (waiting on {{queryResult.job.queueLength}} quer<span ng-if="queryResult.job.queueLength === 1">y</span><span ng-if="queryResult.job.queueLength !== 1">ies</span>)&hellip;
+                  Query in queue (waiting on {{queryResult.job.queue_length}} quer<span ng-if="queryResult.job.queue_length === 1">y</span><span ng-if="queryResult.job.queueLength !== 1">ies</span>)&hellip;
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                   <button type="button" class="btn btn-warning btn-xs pull-right" ng-disabled="cancelling" ng-click="cancelExecution()">Cancel
                   </button>

--- a/client/app/pages/queries/query.html
+++ b/client/app/pages/queries/query.html
@@ -213,7 +213,7 @@
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                 </div>
                 <div class="alert alert-info m-t-15" ng-show="queryResult.getStatus() == 'waiting'">
-                  Query in queue&hellip;
+                  Query in queue (waiting on {{queryResult.job.queueLength}} quer<span ng-if="queryResult.job.queueLength === 1">y</span><span ng-if="queryResult.job.queueLength !== 1">ies</span>)&hellip;
                   <rd-timer timestamp="queryResult.getUpdatedAt()"></rd-timer>
                   <button type="button" class="btn btn-warning btn-xs pull-right" ng-disabled="cancelling" ng-click="cancelExecution()">Cancel
                   </button>

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -181,12 +181,21 @@ class QueryTask(object):
         else:
             query_result_id = None
 
+        queriesAhead = 0
+        if task_status == 'PENDING':
+            waiting = QueryTaskTracker.all(QueryTaskTracker.WAITING_LIST)
+            # find our job's index, return number of queries after it
+            for i, t in enumerate(waiting):
+                if t.data['task_id' ]== self._async_result.id:
+                    queriesAhead = len(waiting) - i - 1
+                    break
         return {
             'id': self._async_result.id,
             'updated_at': updated_at,
             'status': status,
             'error': error,
             'query_result_id': query_result_id,
+            'queueLength': queriesAhead,
         }
 
     @property

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -195,7 +195,7 @@ class QueryTask(object):
             'status': status,
             'error': error,
             'query_result_id': query_result_id,
-            'queueLength': queriesAhead,
+            'queue_length': queriesAhead,
         }
 
     @property

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -181,13 +181,14 @@ class QueryTask(object):
         else:
             query_result_id = None
 
-        queriesAhead = 0
+        queries_ahead = 0
         if task_status == 'PENDING':
             waiting = QueryTaskTracker.all(QueryTaskTracker.WAITING_LIST)
+            waiting_length = len(waiting)
             # find our job's index, return number of queries after it
-            for i, t in enumerate(waiting):
-                if t.data['task_id' ]== self._async_result.id:
-                    queriesAhead = len(waiting) - i - 1
+            for i, waiting_task in enumerate(waiting):
+                if waiting_task.data['task_id'] == self._async_result.id:
+                    queries_ahead = waiting_length - i - 1
                     break
         return {
             'id': self._async_result.id,
@@ -195,7 +196,7 @@ class QueryTask(object):
             'status': status,
             'error': error,
             'query_result_id': query_result_id,
-            'queue_length': queriesAhead,
+            'queue_length': queries_ahead,
         }
 
     @property

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -1,8 +1,9 @@
+import mock
 from tests import BaseTestCase
 
 from redash.models import db
-from redash.utils import json_dumps
-
+from redash.tasks.queries import QueryTaskTracker
+from redash.utils import gen_query_hash, json_dumps
 
 class TestQueryResultsCacheHeaders(BaseTestCase):
     def test_uses_cache_headers_for_specific_result(self):
@@ -38,7 +39,6 @@ class TestQueryResultListAPI(BaseTestCase):
         self.assertEquals(query_result.id, rv.json['query_result']['id'])
 
     def test_execute_new_query(self):
-        query_result = self.factory.create_query_result()
         query = self.factory.create_query()
 
         rv = self.make_request('post', '/api/query_results',
@@ -49,6 +49,45 @@ class TestQueryResultListAPI(BaseTestCase):
         self.assertEquals(rv.status_code, 200)
         self.assertNotIn('query_result', rv.json)
         self.assertIn('job', rv.json)
+
+    def test_queue_length(self):
+        query = self.factory.create_query()
+        tasks = []
+        def fake_all(*a, **kw):
+            return tasks
+        def enqueue_query(query, *a, **kw):
+            from redash.tasks.queries import enqueue_query
+            job = enqueue_query(query, *a, **kw)
+            tasks.append(QueryTaskTracker.create(
+                task_id=job.id,
+                state='waiting',
+                query_hash=gen_query_hash(query),
+                data_source_id=None,
+                scheduled=False,
+                metadata={}))
+            return job
+        patch_all = mock.patch('redash.tasks.queries.QueryTaskTracker.all',
+                               classmethod(fake_all))
+        patch_enqueue_query = mock.patch('redash.handlers.query_results.enqueue_query',
+                                         enqueue_query)
+        with patch_all, patch_enqueue_query:
+            rv0 = self.make_request('post', '/api/query_results',
+                                    data={'data_source_id': self.factory.data_source.id,
+                                          'query': query.query_text,
+                                          'max_age': 0})
+            rv1 = self.make_request('post', '/api/query_results',
+                                    data={'data_source_id': self.factory.data_source.id,
+                                          'query': query.query_text,
+                                          'max_age': 0})
+            rv2 = self.make_request('post', '/api/query_results',
+                                    data={'data_source_id': self.factory.data_source.id,
+                                          'query': query.query_text,
+                                          'max_age': 0})
+
+        self.assertEquals(rv0.json['job']['queue_length'], 0)
+        self.assertEquals(rv1.json['job']['queue_length'], 1)
+        self.assertEquals(rv2.json['job']['queue_length'], 2)
+
 
     def test_execute_query_without_access(self):
         group = self.factory.create_group()


### PR DESCRIPTION
This invokes the same API used in the admin "Running Queries" page to ask redis how many jobs are in the 'waiting' state ahead of the current one.

I tested this locally by stopping the celery worker and executing several queries.
