### PR TITLE
Add query object later to database session.

### DIFF
--- a/redash/models.py
+++ b/redash/models.py
@@ -806,9 +806,9 @@ class QueryResult(db.Model, BelongsToOrgMixin):
         for q in queries:
             q.latest_query_data = query_result
             q.skip_updated_at = True
-            db.session.add(q)
             if q.schedule_resultset_size > 0:
                 q.query_results.append(query_result)
+            db.session.add(q)
         query_ids = [q.id for q in queries]
         logging.info("Updated %s queries with result (%s).", len(query_ids), query_hash)
 


### PR DESCRIPTION
This line was added via #339.

@washort Do you happen to know if SQA worries about the order of how relationship objects are appended in terms of database session? I'm wondering if this is somehome causing #775?