### PR TITLE
Add tag filters to backend-unit-tests to allow deploy-milestone to build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,9 +117,12 @@ workflows:
     jobs:
       - python-flake8-tests
       - legacy-python-flake8-tests
-      - backend-unit-tests
       - frontend-unit-tests
       - frontend-e2e-tests
+      - backend-unit-tests:
+          filters:
+            tags:
+              only: /^m[0-9]+(\.[0-9]+)?$/
       - deploy-master:
           requires:
             - backend-unit-tests


### PR DESCRIPTION
As part of the m19 release we pulled in changes from upstream that updated the CircleCI configuration. These changes are affecting `deploy-milestone` and causing this job to be ignored.

Based on the CircleCI documentation:

>  if a job requires any other jobs (directly or indirectly), you must use regular expressions to specify tag filters for those jobs.

`deploy-milestone` is built only on tags and requires`backend-unit-tests` job however tag filters are not specified here. This change adds tag filters to the `backend-unit-tests` workflow so that `deploy-milestone` jobs are executed. 

https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag to documentation.