### PR TITLE
Hack to check permissions on inputs to 'Query Results' data source

### DIFF
--- a/redash/extract_table_names.py
+++ b/redash/extract_table_names.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2009-2018 the sqlparse authors and contributors
+# <see AUTHORS file>
+#
+# This example is part of python-sqlparse and is released under
+# the BSD License: https://opensource.org/licenses/BSD-3-Clause
+#
+# This example illustrates how to extract table names from nested
+# SELECT statements.
+#
+# See:
+# https://groups.google.com/forum/#!forum/sqlparse/browse_thread/thread/b0bd9a022e9d4895
+
+import sqlparse
+from sqlparse.sql import IdentifierList, Identifier
+from sqlparse.tokens import Keyword, DML
+
+
+def is_subselect(parsed):
+    if not parsed.is_group:
+        return False
+    for item in parsed.tokens:
+        if item.ttype is DML and item.value.upper() == 'SELECT':
+            return True
+    return False
+
+
+def extract_from_part(parsed):
+    from_seen = False
+    for item in parsed.tokens:
+        if from_seen:
+            if is_subselect(item):
+                for x in extract_from_part(item):
+                    yield x
+            elif item.ttype is Keyword:
+                raise StopIteration
+            else:
+                yield item
+        elif item.ttype is Keyword and item.value.upper() == 'FROM':
+            from_seen = True
+
+
+def extract_table_identifiers(token_stream):
+    for item in token_stream:
+        if isinstance(item, IdentifierList):
+            for identifier in item.get_identifiers():
+                yield identifier.get_real_name()
+        elif isinstance(item, Identifier):
+            yield item.get_real_name()
+        # It's a bug to check for Keyword here, but in the example
+        # above some tables names are identified as keywords...
+        elif item.ttype is Keyword:
+            yield item.value
+
+
+def extract_tables(sql):
+    stream = extract_from_part(sqlparse.parse(sql)[0])
+    return list(extract_table_identifiers(stream))

--- a/tests/handlers/test_query_results.py
+++ b/tests/handlers/test_query_results.py
@@ -1,6 +1,6 @@
 from tests import BaseTestCase
 
-from redash.models import db
+from redash.models import db, Group
 from redash.utils import json_dumps
 
 
@@ -150,6 +150,29 @@ class TestQueryResultAPI(BaseTestCase):
         query_result2 = self.factory.create_query_result(data_source=ds2, query_hash='something-different')
 
         rv = self.make_request('get', '/api/queries/{}/results/{}.json'.format(query.id, query_result2.id))
+        self.assertEquals(rv.status_code, 403)
+
+    def test_query_result_query(self):
+        restricted_group = self.factory.create_group(org=self.factory.org, type=Group.REGULAR_GROUP, name="restricted")
+        db.session.commit()
+        restricted_user = self.factory.create_user(group_ids=[restricted_group.id, self.factory.org.default_group.id], name="Restricted User")
+        restricted_ds = self.factory.create_data_source(group=restricted_group, view_only=False, type='result')
+        upstream_query = self.factory.create_query(user=restricted_user, data_source=restricted_ds, query_text="select * from secret")
+        result_ds = self.factory.create_data_source(group=self.factory.org.default_group, view_only=False, type='result')
+        query = self.factory.create_query(user=restricted_user, data_source=result_ds, query_text="select password from query_{} limit 10".format(upstream_query.id))
+        query_result = self.factory.create_query_result(data_source=result_ds, query_text=query.query_text, query_hash=query.query_hash, )
+        rv = self.make_request('get', '/api/query_results/{}'.format(query_result.id), user=restricted_user)
+        self.assertEquals(rv.status_code, 200)
+
+    def test_query_result_query_restrict_access(self):
+        restricted_group = self.factory.create_group(org=self.factory.org, type=Group.REGULAR_GROUP, name="restricted")
+        restricted_user = self.factory.create_user(group_ids=[restricted_group.id, self.factory.org.default_group.id])
+        restricted_ds = self.factory.create_data_source(group=restricted_group, view_only=False, type='result')
+        upstream_query = self.factory.create_query(user=restricted_user, data_source=restricted_ds, query_text="select * from secret")
+        result_ds = self.factory.create_data_source(group=self.factory.org.default_group, view_only=False, type='result')
+        query = self.factory.create_query(user=restricted_user, data_source=result_ds, query_text="select password from query_{}".format(upstream_query.id))
+        query_result = self.factory.create_query_result(data_source=result_ds, query_text=query.query_text, query_hash=query.query_hash, )
+        rv = self.make_request('get', '/api/query_results/{}'.format(query_result.id))
         self.assertEquals(rv.status_code, 403)
 
 


### PR DESCRIPTION
This looks at the query used against the 'query results' data source, identifies the queries it targets, and checks that the user has permission to view results from those queries. If not, permission is not granted to view the output.