### PR TITLE
Fix bug 1529388 - don't include column type in autocomplete results.

### DIFF
--- a/client/app/components/QueryEditor.jsx
+++ b/client/app/components/QueryEditor.jsx
@@ -40,6 +40,9 @@ function buildKeywordsFromSchema(schema) {
   schema.forEach((table) => {
     keywords[table.name] = 'Table';
     table.columns.forEach((c) => {
+      if (c.length > 0) {
+        c = c.split('(')[0];
+      }
       keywords[c] = 'Column';
       keywords[`${table.name}.${c}`] = 'Column';
     });

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -35,7 +35,7 @@ function SchemaBrowserCtrl($rootScope, $scope) {
   };
 
   this.itemSelected = ($event, hierarchy) => {
-    $rootScope.$broadcast('query-editor.command', 'paste', hierarchy.join('.'));
+    $rootScope.$broadcast('query-editor.command', 'paste', hierarchy.join('.').split('(')[0]);
     $event.preventDefault();
     $event.stopPropagation();
   };

--- a/redash/query_runner/pg.py
+++ b/redash/query_runner/pg.py
@@ -140,7 +140,7 @@ class PostgreSQL(BaseSQLQueryRunner):
         AND a.attnum > 0
         AND NOT a.attisdropped
         JOIN pg_type t
-        ON c.reltype = t.oid
+        ON a.atttypid = t.oid
         WHERE c.relkind IN ('r', 'v', 'm', 'f', 'p')
         """
 


### PR DESCRIPTION
This also fixes an issue with the Postgres query runner not showing the actual column type but the table name.