### PR TITLE
Closes #934, #935: Remove type from schema browser and don't show empty example column in schema drawer

### DIFF
--- a/client/app/components/queries/SchemaData.jsx
+++ b/client/app/components/queries/SchemaData.jsx
@@ -30,12 +30,19 @@ class SchemaData extends React.PureComponent {
       dataIndex: 'type',
       width: 400,
       key: 'type',
-    }, {
-      title: 'Example',
-      dataIndex: 'example',
-      width: 400,
-      key: 'example',
     }];
+
+    const hasExample =
+      this.props.tableMetadata.some(columnMetadata => columnMetadata.example);
+
+    if (hasExample) {
+      columns.push({
+        title: 'Example',
+        dataIndex: 'example',
+        width: 400,
+        key: 'example',
+      });
+    }
 
     return (
       <Drawer

--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -34,7 +34,6 @@
       <div uib-collapse="table.collapsed">
         <div ng-repeat="column in table.columns | filter:$ctrl.schemaFilterColumn track by column.key" class="table-open">
           {{column.name}}
-          <span ng-if="column.type !== undefined">({{column.type}})</span>
           <i class="fa fa-angle-double-right copy-to-editor" aria-hidden="true"
             ng-click="$ctrl.itemSelected($event, [column.name])"></i>
         </div>

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -143,9 +143,18 @@ class Athena(BaseQueryRunner):
                     table_name = '%s.%s' % (database['Name'], table['Name'])
                     if table_name not in schema:
                         column = [columns['Name'] for columns in table['StorageDescriptor']['Columns']]
-                        schema[table_name] = {'name': table_name, 'columns': column}
+                        metadata = [{
+                            "name": column_data['Name'],
+                            "type": column_data['Type']
+                        } for column_data in table['StorageDescriptor']['Columns']]
+                        schema[table_name] = {'name': table_name, 'columns': column, 'metadata': metadata}
                         for partition in table.get('PartitionKeys', []):
                             schema[table_name]['columns'].append(partition['Name'])
+                            schema[table_name]['metadata'].append({
+                                "name": partition['Name'],
+                                "type": partition['Type']
+                            })
+
         return schema.values()
 
     def get_schema(self, get_stats=False):

--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -378,7 +378,7 @@ def refresh_schema(data_source_id):
                 "column_metadata": "metadata" in table
             }
             new_column_names[table_name] = table['columns']
-            new_column_metadata[table_name] = table['metadata']
+            new_column_metadata[table_name] = table.get('metadata', None)
 
         insert_or_update_table_metadata(ds, existing_tables_set, table_data)
         models.db.session.flush()

--- a/tests/query_runner/test_athena.py
+++ b/tests/query_runner/test_athena.py
@@ -72,7 +72,11 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['row_id'], 'name': 'test1.jdbc_table'}]
+            assert query_runner.get_schema() == [{
+                'columns': ['row_id'],
+                'name': 'test1.jdbc_table',
+                'metadata': [{'type': 'int', 'name': 'row_id'}]
+            }]
 
     def test_partitioned_table(self):
         """
@@ -118,7 +122,11 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['sk', 'category'], 'name': 'test1.partitioned_table'}]
+            assert query_runner.get_schema() == [{
+                'columns': ['sk', 'category'],
+                'name': 'test1.partitioned_table',
+                'metadata': [{'type': 'int', 'name': 'sk'}, {'type': 'int', 'name': 'category'}]
+            }]
 
     def test_view(self):
         query_runner = Athena({'glue': True, 'region': 'mars-east-1'})
@@ -150,7 +158,11 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['sk'], 'name': 'test1.view'}]
+            assert query_runner.get_schema() == [{
+                'columns': ['sk'],
+                'name': 'test1.view',
+                'metadata': [{'type': 'int', 'name': 'sk'}]
+            }]
 
     def test_dodgy_table_does_not_break_schema_listing(self):
         """
@@ -187,4 +199,8 @@ class TestGlueSchema(TestCase):
             {'DatabaseName': 'test1'},
         )
         with self.stubber:
-            assert query_runner.get_schema() == [{'columns': ['region'], 'name': 'test1.csv'}]
+            assert query_runner.get_schema() == [{
+                'columns': ['region'],
+                'name': 'test1.csv',
+                'metadata': [{'type': 'string', 'name': 'region'}]
+            }]


### PR DESCRIPTION
These are a couple of small UI tweaks related to schema browser changes.

Edit: I've added some more changes.
1. `get_schema()` is now faster with only two postgres queries
2. Column metadata is available when Athena uses glue
3. Fixing a bug in the metadata processing