### PR TITLE
Sample processing should be rate-limited

### DIFF
--- a/redash/cli/data_sources.py
+++ b/redash/cli/data_sources.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from redash import models
 from redash.query_runner import (get_configuration_schema_for_query_runner_type,
                                  query_runners)
+from redash.tasks import refresh_samples
 from redash.utils import json_loads
 from redash.utils.configuration import ConfigurationContainer
 
@@ -170,6 +171,27 @@ def update_attr(obj, attr, new_value):
         old_value = getattr(obj, attr)
         print("Updating {}: {} -> {}".format(attr, old_value, new_value))
         setattr(obj, attr, new_value)
+
+
+@manager.command()
+@click.argument('name')
+@click.option('--org', 'organization', default='default',
+              help="The organization the user belongs to (leave blank for "
+              "'default').")
+@click.option('--count', 'num_tables', default=50,
+              help="number of tables to process data samples for")
+def refresh_data_samples(name, num_tables=50, organization='default'):
+    """Refresh table samples by data source name."""
+    try:
+        org = models.Organization.get_by_slug(organization)
+        data_source = models.DataSource.query.filter(
+            models.DataSource.name == name,
+            models.DataSource.org == org).one()
+        print("Refreshing samples for data source: {} (id={})".format(name, data_source.id))
+        refresh_samples(data_source.id, num_tables)
+    except NoResultFound:
+        print("Couldn't find data source named: {}".format(name))
+        exit(1)
 
 
 @manager.command()

--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -77,6 +77,7 @@ class TableMetadata(TimestampMixin, db.Model):
     description = Column(db.String(4096), nullable=True)
     column_metadata = Column(db.Boolean, default=False)
     sample_query = Column("sample_query", db.Text, nullable=True)
+    sample_updated_at = Column(db.DateTime(True), nullable=True)
 
     __tablename__ = 'table_metadata'
 
@@ -93,6 +94,7 @@ class TableMetadata(TimestampMixin, db.Model):
             'description': self.description,
             'column_metadata': self.column_metadata,
             'sample_query': self.sample_query,
+            'sample_updated_at': self.sample_updated_at,
         }
 
 

--- a/redash/query_runner/athena.py
+++ b/redash/query_runner/athena.py
@@ -43,7 +43,10 @@ class SimpleFormatter(object):
 
 class Athena(BaseQueryRunner):
     noop_query = 'SELECT 1'
-    sample_query = "SELECT * FROM {table} LIMIT 1"
+
+    # This takes a 1% random sample from {table}, reducing
+    # the runtime and data scanned for the query
+    sample_query = "SELECT * FROM {table} TABLESAMPLE SYSTEM (1) LIMIT 1"
 
     @classmethod
     def name(cls):

--- a/redash/query_runner/presto.py
+++ b/redash/query_runner/presto.py
@@ -62,7 +62,10 @@ class Presto(BaseQueryRunner):
             'title': 'Show Data Samples'
         },
     }
-    sample_query = "SELECT * FROM {table} LIMIT 1"
+
+    # This takes a 1% random sample from {table}, reducing
+    # the runtime and data scanned for the query
+    sample_query = "SELECT * FROM {table} TABLESAMPLE SYSTEM (1) LIMIT 1"
 
     @classmethod
     def configuration_schema(cls):

--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -48,6 +48,7 @@ QUERY_RESULTS_CLEANUP_MAX_AGE = int(os.environ.get("REDASH_QUERY_RESULTS_CLEANUP
 
 SCHEMAS_REFRESH_SCHEDULE = int(os.environ.get("REDASH_SCHEMAS_REFRESH_SCHEDULE", 360))
 SCHEMAS_REFRESH_QUEUE = os.environ.get("REDASH_SCHEMAS_REFRESH_QUEUE", "celery")
+SAMPLES_REFRESH_QUEUE = os.environ.get("REDASH_SAMPLES_REFRESH_QUEUE", "celery")
 
 AUTH_TYPE = os.environ.get("REDASH_AUTH_TYPE", "api_key")
 ENFORCE_HTTPS = parse_boolean(os.environ.get("REDASH_ENFORCE_HTTPS", "false"))
@@ -254,6 +255,9 @@ SCHEMA_RUN_TABLE_SIZE_CALCULATIONS = parse_boolean(os.environ.get("REDASH_SCHEMA
 
 # Frequency of clearing out old schema metadata.
 SCHEMA_METADATA_TTL_DAYS = int(os.environ.get("REDASH_SCHEMA_METADATA_TTL_DAYS", 60))
+
+# Frequency of schema samples refresh
+SCHEMA_SAMPLE_REFRESH_FREQUENCY_DAYS = int(os.environ.get("REDASH_SCHEMA_SAMPLE_REFRESH_FREQUENCY_DAYS", 14))
 
 # Allow Parameters in Embeds
 # WARNING: With this option enabled, Redash reads query parameters from the request URL (risk of SQL injection!)

--- a/redash/tasks/__init__.py
+++ b/redash/tasks/__init__.py
@@ -1,3 +1,3 @@
 from .general import record_event, version_check, send_mail, sync_user_details
-from .queries import QueryTask, refresh_queries, refresh_schemas, refresh_schema, cleanup_query_results, execute_query, get_table_sample_data, cleanup_schema_metadata
+from .queries import QueryTask, refresh_queries, refresh_schemas, refresh_schema, cleanup_query_results, execute_query, update_sample, cleanup_schema_metadata, refresh_samples
 from .alerts import check_alerts_for_query

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,10 +3,11 @@ import textwrap
 from click.testing import CliRunner
 
 from tests import BaseTestCase
+from redash import utils
 from redash.utils.configuration import ConfigurationContainer
 from redash.query_runner import query_runners
 from redash.cli import manager
-from redash.models import DataSource, Group, Organization, User, db
+from redash.models import DataSource, TableMetadata, Group, Organization, User, db
 
 
 class DataSourceCommandTests(BaseTestCase):
@@ -138,6 +139,16 @@ class DataSourceCommandTests(BaseTestCase):
         self.assertEqual(result.exit_code, 1)
         self.assertIn("Couldn't find", result.output)
         self.assertEqual(DataSource.query.count(), 1)
+
+    def test_refresh_samples(self):
+        ds = self.factory.create_data_source(
+            name='test1', type='sqlite',
+            options=ConfigurationContainer({"dbpath": "/tmp/test.db"}))
+        runner = CliRunner()
+        result = runner.invoke(manager, ['ds', 'refresh_data_samples', 'test1'])
+        self.assertFalse(result.exception)
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn('Refreshing', result.output)
 
     def test_options_edit(self):
         self.factory.create_data_source(


### PR DESCRIPTION
The motivation for this PR was that processing samples for hundreds of tables seemed to overload Presto.

This PR makes it so that a periodic (once per 6 hours) schema refresh will also process 50 tables' samples each time. This way the load is more spread out.