### PR TITLE
Require a more up-to-date version of importlib-metadata.

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -5,6 +5,6 @@
 redash-stmo>=2019.7.4
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata==0.9  # remove when on 3.8
+importlib-metadata>=0.19  # remove when on 3.8
 importlib_resources==1.0.2  # remove when on 3.7
 pathlib2==2.3.3  # remove when on 3.x


### PR DESCRIPTION
This is needed since kombu just switched to importlib-metadata as well and requires a newer version of it (https://github.com/celery/kombu/commit/5b44bf94fa20532082507d6825aef2cb7b8d1883).