### PR TITLE
Increase the hard timeout for refresh_schema to 25 min

### DIFF
--- a/redash/tasks/queries.py
+++ b/redash/tasks/queries.py
@@ -447,7 +447,7 @@ def insert_or_update_column_metadata(table, existing_columns_set, column_data):
     )
 
 
-@celery.task(name="redash.tasks.refresh_schema", time_limit=600, soft_time_limit=300)
+@celery.task(name="redash.tasks.refresh_schema", time_limit=1500, soft_time_limit=1200)
 def refresh_schema(data_source_id):
     ds = models.DataSource.get_by_id(data_source_id)
     logger.info(u"task=refresh_schema state=start ds_id=%s", ds.id)


### PR DESCRIPTION
Schema processing was timing out too soon. When tested manually, `BigQuery (Beta)` took ~21 min to update. But a subsequent update took ~13min. If a basic update taking 13min failed each time, a buildup of updates resulted in that one large 21min update.

So this new hard timeout of 25min is being very generous but hopefully most schema refresh tasks would finish much sooner. We can keep an eye on the time tasks are taking in the logs.