### PR TITLE
Pin redash-stmo to pre-iodide extraction.

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -3,7 +3,7 @@
 # when moved to Python 3.
 # It's automatically installed when running npm run bundle
 # This is the Mozilla Redash extension
-redash-stmo>=2019.9.0
+redash-stmo>=2019.9.0,<2019.11.0
 
 # These can be removed when upgrading to Python 3.x
 importlib-metadata>=0.19  # remove when on 3.8


### PR DESCRIPTION
Now that the Iodide feature set is in a separate redash-iodide repo, we need to pin redash-stmo for an older version until the next major mXX release.