### PR TITLE
Don't immediately remove notifications from notification trays (backport getredash#4773)

### DIFF
--- a/client/app/services/notifications.js
+++ b/client/app/services/notifications.js
@@ -39,9 +39,6 @@ class NotificationsService {
       body: content,
       icon: "/images/redash_icon_small.png",
     });
-    setTimeout(() => {
-      notification.close();
-    }, 3000);
     notification.onclick = function onClick() {
       window.focus();
       this.close();


### PR DESCRIPTION
Let the notifications go into browser/OS notification trays so users can click on them from there if they miss the initial notification. Modern browsers generally use OS notifications so the user is in control of the notification at the OS level. The current 3s delay isn't a good UX and is quite frustrating when I have multiple monitors and windows and can't find the query that finished easily.

This is a trivial backport of https://github.com/getredash/redash/pull/4773 which was merged to master upstream.

It wasn't clear which branch I was supposed to use in our Mozilla fork but I think release is correct.