### PR TITLE
Fix build: Set max version for importlib-metadata bc 5.0.0 removes endpoint we need

### DIFF
--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -6,5 +6,5 @@
 redash-stmo>=2019.9.0
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=1.6  # remove when on 3.8
+importlib-metadata>=1.6,<5.0.0  # remove when on 3.8
 importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
`importlib-metadata` python dependency removed deprecated endpoints that we use, so this PR sets the max version allowed to `<5.0.0`.